### PR TITLE
Just specify atom-text-editor:not(.mini)

### DIFF
--- a/keymaps/center-line.cson
+++ b/keymaps/center-line.cson
@@ -3,5 +3,5 @@
 # would be nice if packages automatically overrode core and user automatically overrode
 # packages.
 
-'.platform-darwin atom-workspace atom-text-editor:not(.mini)':
+'atom-text-editor:not(.mini)':
   'ctrl-l': 'center-line:toggle'


### PR DESCRIPTION
So it works in linux with atom 1.0.19
